### PR TITLE
Python style changes

### DIFF
--- a/benchmarking/pyctest_tomopy_phantom.py
+++ b/benchmarking/pyctest_tomopy_phantom.py
@@ -68,7 +68,8 @@ def run(phantom, algorithm, args, get_recon=False):
         _kwargs["num_iter"] = args.num_iter
 
     print("kwargs: {}".format(_kwargs))
-    with timemory.util.auto_timer("[tomopy.recon(algorithm='{}')]".format(algorithm)):
+    with timemory.util.auto_timer("[tomopy.recon(algorithm='{}')]".format(
+                                  algorithm)):
         rec = tomopy.recon(prj, ang, **_kwargs)
 
     obj = normalize(obj)
@@ -109,17 +110,18 @@ def main(args):
     if len(args.compare) > 0:
         algorithm = "comparison"
 
-    print('\nArguments:\n{} = {}\n{} = {}\n{} = {}\n{} = {}\n{} = {}\n{} = {}\n{} = {}\n{} = {}\n{} = {}\n{} = {}\n'.format(
-        "\tPhantom", args.phantom,
-        "\tAlgorithm", algorithm,
-        "\tSize", args.size,
-        "\tAngles", args.angles,
-        "\tFormat", args.format,
-        "\tScale", args.scale,
-        "\tcomparison", args.compare,
-        "\tnumber of cores", args.ncores,
-        "\tnumber of columns", args.ncol,
-        "\tnumber iterations", args.num_iter))
+    print(("\nArguments:\n{} = {}\n{} = {}\n{} = {}\n{} = {}\n{} = {}\n"
+          "{} = {}\n{} = {}\n{} = {}\n{} = {}\n{} = {}\n").format(
+          "\tPhantom", args.phantom,
+          "\tAlgorithm", algorithm,
+          "\tSize", args.size,
+          "\tAngles", args.angles,
+          "\tFormat", args.format,
+          "\tScale", args.scale,
+          "\tcomparison", args.compare,
+          "\tnumber of cores", args.ncores,
+          "\tnumber of columns", args.ncol,
+          "\tnumber iterations", args.num_iter))
 
     if len(args.compare) > 0:
         args.ncol = 1
@@ -131,8 +133,10 @@ def main(args):
             tmp = run(args.phantom, alg, args, get_recon=True)
             tmp = rescale_image(tmp, args.size, args.scale, transform=False)
             if comparison is None:
-                comparison = image_comparison(len(
-                    args.compare), tmp.shape[0], tmp[0].shape[0], tmp[0].shape[1], image_quality["orig"])
+                comparison = image_comparison(
+                    len(args.compare), tmp.shape[0], tmp[0].shape[0],
+                    tmp[0].shape[1], image_quality["orig"]
+                    )
             comparison.assign(alg, nitr, tmp)
             nitr += 1
         bname = get_basepath(args, algorithm, args.phantom)
@@ -160,7 +164,8 @@ def main(args):
 
     # provide timing plots
     try:
-        timemory.plotting.plot(files=[timemory.options.serial_filename], echo_dart=True,
+        timemory.plotting.plot(files=[timemory.options.serial_filename],
+                               echo_dart=True,
                                output_dir=timemory.options.output_dir)
     except Exception as e:
         print("Exception - {}".format(e))
@@ -181,7 +186,8 @@ def main(args):
     # provide ASCII results
     try:
         notes = manager.write_ctest_notes(
-            directory="{}/{}/{}".format(args.output_dir, args.phantom, algorithm))
+            directory="{}/{}/{}".format(args.output_dir, args.phantom,
+                                        algorithm))
         print('"{}" wrote CTest notes file : {}'.format(__file__, notes))
     except Exception as e:
         print("Exception - {}".format(e))
@@ -210,7 +216,8 @@ if __name__ == "__main__":
                         default=ncores, type=int)
     parser.add_argument("-f", "--format", help="output image format",
                         default="jpeg", type=str)
-    parser.add_argument("-S", "--scale", help="scale image by a positive factor",
+    parser.add_argument("-S", "--scale",
+                        help="scale image by a positive factor",
                         default=1, type=int)
     parser.add_argument("-c", "--ncol", help="Number of images per row",
                         default=1, type=int)

--- a/benchmarking/pyctest_tomopy_phantom.py
+++ b/benchmarking/pyctest_tomopy_phantom.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-"""
-TomoPy script to reconstruct a built-in phantom
-"""
+"""TomoPy script to reconstruct a built-in phantom."""
 
 import sys
 import os
@@ -64,7 +62,7 @@ def run(phantom, algorithm, args, get_recon=False):
     _kwargs["ncore"] = ncores
 
     # don't assign "num_iter" if gridrec or fbp
-    if not algorithm in ["fbp", "gridrec"]:
+    if algorithm not in ["fbp", "gridrec"]:
         _kwargs["num_iter"] = args.num_iter
 
     print("kwargs: {}".format(_kwargs))
@@ -83,7 +81,7 @@ def run(phantom, algorithm, args, get_recon=False):
 
     quantify_difference(label, obj, rec)
 
-    if not "orig" in image_quality:
+    if "orig" not in image_quality:
         image_quality["orig"] = obj
 
     dif = obj - rec

--- a/benchmarking/pyctest_tomopy_phantom.py
+++ b/benchmarking/pyctest_tomopy_phantom.py
@@ -20,18 +20,17 @@ import signal
 import numpy as np
 import time as t
 import pylab
+
 try:
     from pyctest_tomopy_utils import *
 except:
     from benchmarking.pyctest_tomopy_utils import *
 
 
-#------------------------------------------------------------------------------#
 def get_basepath(args, algorithm, phantom):
     return os.path.join(os.getcwd(), args.output_dir, phantom, algorithm)
 
 
-#------------------------------------------------------------------------------#
 @timemory.util.auto_timer()
 def generate(phantom="shepp3d", nsize=512, nangles=360):
 
@@ -45,7 +44,6 @@ def generate(phantom="shepp3d", nsize=512, nangles=360):
     return [prj, ang, obj]
 
 
-#------------------------------------------------------------------------------#
 @timemory.util.auto_timer()
 def run(phantom, algorithm, args, get_recon=False):
 
@@ -101,7 +99,6 @@ def run(phantom, algorithm, args, get_recon=False):
     return imgs
 
 
-#------------------------------------------------------------------------------#
 def main(args):
 
     global image_quality
@@ -161,7 +158,6 @@ def main(args):
     timemory.options.set_serial("run_tomopy.json")
     manager.report()
 
-    #------------------------------------------------------------------#
     # provide timing plots
     try:
         timemory.plotting.plot(files=[timemory.options.serial_filename], echo_dart=True,
@@ -169,7 +165,6 @@ def main(args):
     except Exception as e:
         print("Exception - {}".format(e))
 
-    #------------------------------------------------------------------#
     # provide results to dashboard
     try:
         for i in range(0, len(imgs)):
@@ -183,7 +178,6 @@ def main(args):
     except Exception as e:
         print("Exception - {}".format(e))
 
-    #------------------------------------------------------------------#
     # provide ASCII results
     try:
         notes = manager.write_ctest_notes(
@@ -193,7 +187,6 @@ def main(args):
         print("Exception - {}".format(e))
 
 
-#------------------------------------------------------------------------------#
 if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()

--- a/benchmarking/pyctest_tomopy_rec.py
+++ b/benchmarking/pyctest_tomopy_rec.py
@@ -121,7 +121,7 @@ def reconstruct(h5fname, sino, rot_center, args, blocked_views=None):
     _kwargs["ncore"] = ncores
 
     # don't assign "num_iter" if gridrec or fbp
-    if not algorithm in ["fbp", "gridrec"]:
+    if algorithm not in ["fbp", "gridrec"]:
         _kwargs["num_iter"] = nitr
 
     # Reconstruct object.

--- a/benchmarking/pyctest_tomopy_rec.py
+++ b/benchmarking/pyctest_tomopy_rec.py
@@ -25,7 +25,6 @@ except:
     from benchmarking.pyctest_tomopy_utils import *
 
 
-#------------------------------------------------------------------------------#
 def get_dx_dims(fname, dataset):
     """
     Read array size of a specific group of Data Exchange file.
@@ -56,7 +55,6 @@ def get_dx_dims(fname, dataset):
     return shape
 
 
-#------------------------------------------------------------------------------#
 def restricted_float(x):
 
     x = float(x)
@@ -65,7 +63,6 @@ def restricted_float(x):
     return x
 
 
-#------------------------------------------------------------------------------#
 def read_rot_centers(fname):
 
     try:
@@ -82,7 +79,6 @@ def read_rot_centers(fname):
         exit()
 
 
-#------------------------------------------------------------------------------#
 @timemory.util.auto_timer()
 def reconstruct(h5fname, sino, rot_center, args, blocked_views=None):
 
@@ -134,7 +130,6 @@ def reconstruct(h5fname, sino, rot_center, args, blocked_views=None):
     return rec
 
 
-#------------------------------------------------------------------------------#
 @timemory.util.auto_timer()
 def rec_full(h5fname, rot_center, args, blocked_views, nchunks=16):
 
@@ -183,7 +178,6 @@ def rec_full(h5fname, rot_center, args, blocked_views, nchunks=16):
     return imgs
 
 
-#------------------------------------------------------------------------------#
 @timemory.util.auto_timer()
 def rec_slice(h5fname, nsino, rot_center, args, blocked_views):
 
@@ -213,7 +207,7 @@ def rec_slice(h5fname, nsino, rot_center, args, blocked_views):
     imgs.extend(output_images(rec, fname, args.format, args.scale, args.ncol))
     return imgs
 
-#------------------------------------------------------------------------------#
+
 def main(arg):
 
     import multiprocessing as mp
@@ -285,7 +279,6 @@ def main(arg):
     else:
         print("File Name does not exist: ", fname)
 
-    #
     # timing report to stdout
     print('{}'.format(manager))
 
@@ -294,8 +287,6 @@ def main(arg):
     timemory.options.set_report("run_tomopy.out")
     timemory.options.set_serial("run_tomopy.json")
     manager.report()
-
-    #------------------------------------------------------------------#
     # provide timing plots
     try:
         print("\nPlotting TiMemory results...\n")
@@ -304,8 +295,6 @@ def main(arg):
                                output_dir=timemory.options.output_dir)
     except Exception as e:
         print("Exception [timemory.plotting] - {}".format(e))
-
-    #------------------------------------------------------------------#
     # provide results to dashboard
     try:
         print("\nEchoing dart tags...\n")
@@ -321,8 +310,6 @@ def main(arg):
             timemory.plotting.echo_dart_tag(img_name, img_path, img_type)
     except Exception as e:
         print("Exception [echo_dart_tag] - {}".format(e))
-
-    #------------------------------------------------------------------#
     # provide ASCII results
     try:
         print("\nWriting notes...\n")
@@ -330,6 +317,7 @@ def main(arg):
         print('"{}" wrote CTest notes file : {}'.format(__file__, notes))
     except Exception as e:
         print("Exception [write_ctest_notes] - {}".format(e))
+
 
 if __name__ == "__main__":
     ret = 0
@@ -340,5 +328,4 @@ if __name__ == "__main__":
         traceback.print_exception(exc_type, exc_value, exc_traceback, limit=5)
         print('Exception - {}'.format(e))
         ret = 1
-
     sys.exit(ret)

--- a/benchmarking/pyctest_tomopy_rec.py
+++ b/benchmarking/pyctest_tomopy_rec.py
@@ -59,7 +59,7 @@ def restricted_float(x):
 
     x = float(x)
     if x < 0.0 or x >= 1.0:
-        raise argparse.ArgumentTypeError("%r not in range [0.0, 1.0]"%(x,))
+        raise argparse.ArgumentTypeError("%r not in range [0.0, 1.0]" % (x,))
     return x
 
 
@@ -73,7 +73,8 @@ def read_rot_centers(fname):
         return collections.OrderedDict(sorted(dictionary.items()))
 
     except Exception as error:
-        print("ERROR: the json file containing the rotation axis locations is missing")
+        print("ERROR: the json file containing the rotation axis locations "
+              "is missing")
         print("ERROR: run: python find_center.py to create one first")
         print("Error: {}".format(error))
         exit()
@@ -88,14 +89,17 @@ def reconstruct(h5fname, sino, rot_center, args, blocked_views=None):
     # Manage the missing angles:
     if blocked_views is not None:
         print("Blocked Views: ", blocked_views)
-        proj = np.concatenate((proj[0:blocked_views[0],:,:], proj[blocked_views[1]+1:-1,:,:]), axis=0)
-        theta = np.concatenate((theta[0:blocked_views[0]], theta[blocked_views[1]+1:-1]))
+        proj = np.concatenate((proj[0:blocked_views[0], :, :],
+                               proj[blocked_views[1]+1:-1, :, :]), axis=0)
+        theta = np.concatenate((theta[0:blocked_views[0]],
+                                theta[blocked_views[1]+1: -1]))
 
     # Flat-field correction of raw data.
     data = tomopy.normalize(proj, flat, dark, cutoff=1.4)
 
     # remove stripes
-    data = tomopy.remove_stripe_fw(data,level=7,wname='sym16',sigma=1,pad=True)
+    data = tomopy.remove_stripe_fw(data, level=7, wname='sym16', sigma=1,
+                                   pad=True)
 
     print("Raw data: ", h5fname)
     print("Center: ", rot_center)
@@ -121,7 +125,8 @@ def reconstruct(h5fname, sino, rot_center, args, blocked_views=None):
         _kwargs["num_iter"] = nitr
 
     # Reconstruct object.
-    with timemory.util.auto_timer("[tomopy.recon(algorithm='{}')]".format(algorithm)):
+    with timemory.util.auto_timer("[tomopy.recon(algorithm='{}')]".format(
+                                  algorithm)):
         rec = tomopy.recon(proj, theta, **_kwargs)
 
     # Mask each reconstructed slice with a circle.
@@ -143,13 +148,16 @@ def rec_full(h5fname, rot_center, args, blocked_views, nchunks=16):
     sino_start = 0
     sino_end = data_size[1]
 
-    chunks = nchunks    # number of sinogram chunks to reconstruct
-                        # only one chunk at the time is reconstructed
-                        # allowing for limited RAM machines to complete a full reconstruction
+    # The number of sinogram chunks to reconstruct. Only one chunk at the time
+    # is reconstructed allowing for limited RAM machines to complete a full
+    # reconstruction.
+    chunks = nchunks
 
     nSino_per_chunk = (sino_end - sino_start)/chunks
-    print("Reconstructing [%d] slices from slice [%d] to [%d] in [%d] chunks of [%d] slices each" %
-        ((sino_end - sino_start), sino_start, sino_end, chunks, nSino_per_chunk))
+    print("Reconstructing [%d] slices from slice [%d] to [%d] "
+          "in [%d] chunks of [%d] slices each" %
+          ((sino_end - sino_start), sino_start, sino_end,
+           chunks, nSino_per_chunk))
 
     imgs = []
     strt = 0
@@ -168,11 +176,12 @@ def rec_full(h5fname, rot_center, args, blocked_views, nchunks=16):
         rec = reconstruct(h5fname, sino, rot_center, args, blocked_views)
 
         # Write data as stack of TIFs.
-        fname = os.path.join(output_dir,'recon_{}_'.format(args.algorithm))
+        fname = os.path.join(output_dir, 'recon_{}_'.format(args.algorithm))
         print("Reconstructions: ", fname)
 
-        imgs.extend(output_images(rec, fname, args.format, args.scale, args.ncol))
-        #dxchange.write_tiff_stack(rec, fname=fname, start=strt)
+        imgs.extend(output_images(rec, fname, args.format, args.scale,
+                                  args.ncol))
+        # dxchange.write_tiff_stack(rec, fname=fname, start=strt)
         strt += sino[1] - sino[0]
 
     return imgs
@@ -199,9 +208,9 @@ def rec_slice(h5fname, nsino, rot_center, args, blocked_views):
     # Reconstruct
     rec = reconstruct(h5fname, sino, rot_center, args, blocked_views)
 
-    fname = os.path.join(output_dir,'recon_{}_'.format(args.algorithm))
+    fname = os.path.join(output_dir, 'recon_{}_'.format(args.algorithm))
 
-    #dxchange.write_tiff_stack(rec, fname=fname)
+    # dxchange.write_tiff_stack(rec, fname=fname)
     print("Rec: ", fname)
     print("Slice: ", start)
     imgs.extend(output_images(rec, fname, args.format, args.scale, args.ncol))
@@ -215,20 +224,29 @@ def main(arg):
 
     parser = argparse.ArgumentParser()
     parser.add_argument("fname",
-        help="file name of a tmographic dataset: /data/sample.h5")
+                        help=("file name of a tmographic dataset: "
+                              "/data/sample.h5")
+                        )
     parser.add_argument("--axis", nargs='?', type=str, default="0",
-        help="rotation axis location: 1024.0 (default 1/2 image horizontal size)")
+                        help=("rotation axis location: 1024.0 "
+                              "(default 1/2 image horizontal size)")
+                        )
     parser.add_argument("--type", nargs='?', type=str, default="slice",
-        help="reconstruction type: full (default slice)")
-    parser.add_argument("--nsino", nargs='?', type=restricted_float, default=0.5,
-        help="location of the sinogram used by slice reconstruction (0 top, 1 bottom): 0.5 (default 0.5)")
+                        help="reconstruction type: full (default slice)")
+    parser.add_argument("--nsino", nargs='?', type=restricted_float,
+                        default=0.5,
+                        help=("location of the sinogram used by slice "
+                              "reconstruction (0 top, 1 bottom): 0.5 "
+                              "(default 0.5)")
+                        )
     parser.add_argument("-a", "--algorithm", help="Select the algorithm",
                         default="gridrec", choices=algorithms, type=str)
     parser.add_argument("-n", "--ncores", help="number of cores",
                         default=default_ncores, type=int)
     parser.add_argument("-f", "--format", help="output image format",
                         default="jpeg", type=str)
-    parser.add_argument("-S", "--scale", help="scale image by a positive factor",
+    parser.add_argument("-S", "--scale",
+                        help="scale image by a positive factor",
                         default=1, type=int)
     parser.add_argument("-c", "--ncol", help="Number of images per row",
                         default=1, type=int)
@@ -236,7 +254,8 @@ def main(arg):
                         default=1, type=int)
     parser.add_argument("-o", "--output-dir", help="Output directory",
                         default=None, type=str)
-    parser.add_argument("-g", "--grainsize", help="Granularity of slices to compute",
+    parser.add_argument("-g", "--grainsize",
+                        help="Granularity of slices to compute",
                         default=16, type=int)
 
     args = parser.parse_args()
@@ -274,7 +293,8 @@ def main(arg):
         if slice:
             imgs = rec_slice(fname, nsino, rot_center, args, blocked_views)
         else:
-            imgs = rec_full(fname, rot_center, args, blocked_views, args.grainsize)
+            imgs = rec_full(fname, rot_center, args, blocked_views,
+                            args.grainsize)
 
     else:
         print("File Name does not exist: ", fname)
@@ -306,7 +326,8 @@ def main(arg):
                 ".{}".format(args.format), "")
             print("Image name: {}".format(img_name))
             img_path = imgs[i]
-            print("name: {}, type: {}, path: {}".format(img_name, img_type, img_path))
+            print("name: {}, type: {}, path: {}".format(img_name, img_type,
+                                                        img_path))
             timemory.plotting.echo_dart_tag(img_name, img_path, img_type)
     except Exception as e:
         print("Exception [echo_dart_tag] - {}".format(e))

--- a/benchmarking/pyctest_tomopy_utils.py
+++ b/benchmarking/pyctest_tomopy_utils.py
@@ -71,13 +71,13 @@ def convert_image(fname, current_format, new_format):
         img = Image.open(_cur_img)
         out = img.convert("RGB")
         out.save(fname, "jpeg", quality=95)
-        print("  --> Converted '{}' to {} format...".format(fname, new_format.upper()))
+        print("  --> Converted '{}' to {} format...".format(fname,
+                                                            new_format.upper()))
 
     except Exception as e:
-
         print("  --> ##### {}...".format(e))
-        print("  --> ##### Exception occurred converting '{}' to {} format...".format(
-            fname, new_format.upper()))
+        print("  --> ##### Exception occurred converting "
+              "'{}' to {} format...".format(fname, new_format.upper()))
 
         _fext = current_format
         _success = False
@@ -156,8 +156,10 @@ def rescale_image(rec, nimages, scale, transform=True):
             _ncols = rec[0].shape[1] * scale
             rec_tmp = np.ndarray([nimages, _nrows, _ncols])
             for i in range(nimages):
-                rec_tmp[i] = skimage.transform.resize(rec_n[i],
-                                                      (rec_n[i].shape[0] * scale, rec_n[i].shape[1] * scale))
+                rec_tmp[i] = skimage.transform.resize(
+                    rec_n[i],
+                    (rec_n[i].shape[0] * scale, rec_n[i].shape[1] * scale)
+                    )
             rec_n = rec_tmp
 
     except Exception as e:
@@ -260,7 +262,8 @@ class image_comparison(object):
     A class for combining image slices into a column comparison
     """
 
-    def __init__(self, ncompare, nslice, nrows, ncols, solution=None, dtype=float):
+    def __init__(self, ncompare, nslice, nrows, ncols, solution=None,
+                 dtype=float):
         self.input_dims = [nslice, nrows, ncols]
         self.store_dims = [nslice, nrows, ncols * (ncompare + 1)]
         self.tags = ["soln"]

--- a/benchmarking/pyctest_tomopy_utils.py
+++ b/benchmarking/pyctest_tomopy_utils.py
@@ -23,7 +23,6 @@ import matplotlib.pyplot as plt
 import numpy.linalg as LA
 
 
-#------------------------------------------------------------------------------#
 def exit_action(errcode):
     man = timemory.manager()
     timemory.report(ign_cutoff=True)
@@ -33,17 +32,14 @@ def exit_action(errcode):
     f.close()
 
 
-#------------------------------------------------------------------------------#
 algorithms = ['gridrec', 'art', 'fbp', 'bart', 'mlem', 'osem', 'sirt',
               'ospml_hybrid', 'ospml_quad', 'pml_hybrid', 'pml_quad',
               'tv', 'grad']
 
 
-#------------------------------------------------------------------------------#
 image_quality = {}
 
 
-#------------------------------------------------------------------------------#
 def output_image(image, fname):
 
     img = pylab.imsave(fname, image, cmap='gray')
@@ -55,7 +51,6 @@ def output_image(image, fname):
         print("  --> No image file at @ '{}' (expected) ...".format(fname))
 
 
-#------------------------------------------------------------------------------#
 def print_size(rec, msg=""):
     print("{} Image size: {} x {} x {}".format(
         msg,
@@ -64,7 +59,6 @@ def print_size(rec, msg=""):
         rec.shape[0]))
 
 
-#------------------------------------------------------------------------------#
 def convert_image(fname, current_format, new_format):
 
     _fext = new_format
@@ -92,7 +86,6 @@ def convert_image(fname, current_format, new_format):
     return [_fname, _success, _fext]
 
 
-#------------------------------------------------------------------------------#
 def normalize(rec):
     rec_n = rec.copy()
     try:
@@ -109,7 +102,6 @@ def normalize(rec):
     return rec_n
 
 
-#------------------------------------------------------------------------------#
 def trim_border(rec, nimages, drow, dcol):
 
     rec_n = rec.copy()
@@ -132,7 +124,6 @@ def trim_border(rec, nimages, drow, dcol):
     return rec_n
 
 
-#------------------------------------------------------------------------------#
 def fill_border(rec, nimages, drow, dcol):
 
     rec_n = rec.copy()
@@ -155,7 +146,6 @@ def fill_border(rec, nimages, drow, dcol):
     return rec_n
 
 
-#------------------------------------------------------------------------------#
 def rescale_image(rec, nimages, scale, transform=True):
 
     rec_n = normalize(rec.copy())
@@ -177,7 +167,6 @@ def rescale_image(rec, nimages, scale, transform=True):
     return rec_n
 
 
-#------------------------------------------------------------------------------#
 def quantify_difference(label, img, rec):
 
     _img = normalize(img)
@@ -217,7 +206,6 @@ def quantify_difference(label, img, rec):
     return [[_l1_pix, _l2_pix], [_l1_grad, _l2_grad]]
 
 
-#------------------------------------------------------------------------------#
 @timemory.util.auto_timer()
 def output_images(rec, fpath, format="jpeg", scale=1, ncol=1):
 
@@ -267,7 +255,6 @@ def output_images(rec, fpath, format="jpeg", scale=1, ncol=1):
     return imgs
 
 
-#------------------------------------------------------------------------------#
 class image_comparison(object):
     """
     A class for combining image slices into a column comparison

--- a/pyctest_tomopy.py
+++ b/pyctest_tomopy.py
@@ -18,8 +18,6 @@ import pyctest.pycmake as pycmake
 import pyctest.helpers as helpers
 
 
-#------------------------------------------------------------------------------#
-#
 def cleanup(path=None, exclude=[]):
     files = [ "coverage.xml", "pyctest_tomopy_rec.py",
                "pyctest_tomopy_phantom.py", "pyctest_tomopy_utils.py",
@@ -31,14 +29,10 @@ def cleanup(path=None, exclude=[]):
     import glob
     files += glob.glob(os.path.join(os.getcwd(), "config", "*.o"))
     files += glob.glob(os.path.join(os.getcwd(), "config", "*.gc*"))
-
     helpers.Cleanup(path, extra=files, exclude=exclude)
 
 
-#------------------------------------------------------------------------------#
-#
 def configure():
-
     # Get pyctest argument parser that include PyCTest arguments
     parser = helpers.ArgumentParser(project_name="TomoPy",
                                     source_dir=os.getcwd(),
@@ -46,7 +40,6 @@ def configure():
                                     python_exe=sys.executable,
                                     submit=False,
                                     ctest_args=["-V"])
-
     # default algorithm choices
     available_algorithms = ['gridrec', 'art', 'fbp', 'bart', 'mlem', 'osem', 'sirt',
                             'ospml_hybrid', 'ospml_quad', 'pml_hybrid', 'pml_quad',
@@ -54,7 +47,6 @@ def configure():
     # default phantom choices
     available_phantoms = ["baboon", "cameraman", "barbara", "checkerboard",
                           "lena", "peppers", "shepp2d", "shepp3d"]
-
     # choices for algorithms
     algorithm_choices = ['gridrec', 'art', 'fbp', 'bart', 'mlem', 'osem', 'sirt',
                          'ospml_hybrid', 'ospml_quad', 'pml_hybrid', 'pml_quad',
@@ -62,18 +54,14 @@ def configure():
     # phantom choices
     phantom_choices = ["baboon", "cameraman", "barbara", "checkerboard",
                        "lena", "peppers", "shepp2d", "shepp3d", "none", "all"]
-
     # number of iterations
     default_nitr = 10
-
     # number of cores
     default_ncores = multiprocessing.cpu_count()
-
     # default algorithm choices
     default_algorithms = ['gridrec', 'art', 'fbp', 'bart', 'mlem', 'osem', 'sirt',
                           'ospml_hybrid', 'ospml_quad', 'pml_hybrid', 'pml_quad',
                           'tv', 'grad']
-
     # default phantom choices
     default_phantoms = ["baboon", "cameraman", "barbara", "checkerboard",
                         "lena", "peppers", "shepp2d", "shepp3d"]
@@ -122,7 +110,6 @@ def configure():
                         help="Disable running phantom tests",
                         action='store_true',
                         default=False)
-
     # calls PyCTest.helpers.ArgumentParser.parse_args()
     args = parser.parse_args()
 
@@ -133,16 +120,12 @@ def configure():
     if not args.skip_cleanup:
         cleanup(pyctest.BINARY_DIRECTORY)
 
-    #-----------------------------------#
     def remove_entry(entry, container):
         if entry in container:
             container.remove(entry)
-    #-----------------------------------#
 
-    #-----------------------------------#
     def remove_duplicates(container):
         container = list(set(container))
-    #-----------------------------------#
 
     if "all" in args.algorithms:
         remove_entry("all", args.algorithms)
@@ -176,17 +159,10 @@ def configure():
     return args
 
 
-#------------------------------------------------------------------------------#
 def run_pyctest():
-
-    #--------------------------------------------------------------------------#
     # run argparse, checkout source, copy over files
-    #
     args = configure()
-
-    #--------------------------------------------------------------------------#
     # Change the build name to somthing other than default
-    #
     pyctest.BUILD_NAME = "[{}] [{} {} {}] [Python ({}) {}]".format(
         pyctest.GetGitBranch(pyctest.SOURCE_DIRECTORY),
         platform.uname()[0],
@@ -194,29 +170,17 @@ def run_pyctest():
         platform.uname()[4],
         platform.python_implementation(),
         platform.python_version())
-
-    #--------------------------------------------------------------------------#
     # when coverage is enabled, we compile in debug so modify the build name
     # so that the history of test timing is not affected
-    #
     if args.coverage:
         pyctest.BUILD_NAME = "{} [coverage]".format(pyctest.BUILD_NAME)
-
-    #--------------------------------------------------------------------------#
     # remove any consecutive spaces
-    #
     while "  " in pyctest.BUILD_NAME:
         pyctest.BUILD_NAME = pyctest.BUILD_NAME.replace("  ", " ")
-
-    #--------------------------------------------------------------------------#
     # how to build the code
-    #
     pyctest.BUILD_COMMAND = "{} setup.py install".format(
         pyctest.PYTHON_EXECUTABLE)
-
-    #--------------------------------------------------------------------------#
     # generate the code coverage
-    #
     python_path = os.path.dirname(pyctest.PYTHON_EXECUTABLE)
     cover_exe = helpers.FindExePath("coverage", path=python_path)
     if args.coverage:
@@ -228,28 +192,19 @@ def run_pyctest():
     else:
         # assign to just generate python coverage
         pyctest.COVERAGE_COMMAND = "{};xml".format(cover_exe)
-
-    #--------------------------------------------------------------------------#
     # copy over files from os.getcwd() to pyctest.BINARY_DIR
     # (implicitly copies over PyCTest{Pre,Post}Init.cmake if they exist)
-    #
     copy_files = [os.path.join("benchmarking", "pyctest_tomopy_utils.py"),
                   os.path.join("benchmarking", "pyctest_tomopy_phantom.py"),
                   os.path.join("benchmarking", "pyctest_tomopy_rec.py")]
     pyctest.copy_files(copy_files)
-
-    #--------------------------------------------------------------------------#
     # find the CTEST_TOKEN_FILE
-    #
     home = helpers.GetHomePath()
     if home is not None:
         token_path = os.path.join(home, ".tokens", "nersc-tomopy")
         if os.path.exists(token_path):
             pyctest.set("CTEST_TOKEN_FILE", token_path)
-
-    #--------------------------------------------------------------------------#
     # create a CTest that checks we imported the correct module
-    #
     test = pyctest.test()
     test.SetName("correct_module")
     test.SetCommand([pyctest.PYTHON_EXECUTABLE, "-c",
@@ -260,10 +215,7 @@ def run_pyctest():
     # set directory to run test
     test.SetProperty("WORKING_DIRECTORY", pyctest.BINARY_DIRECTORY)
     test.SetProperty("ENVIRONMENT", "OMP_NUM_THREADS=1")
-
-    #--------------------------------------------------------------------------#
     # create a CTest that wraps "nosetest"
-    #
     test = pyctest.test()
     test.SetName("nosetests")
     nosetest_exe = helpers.FindExePath("nosetests", path=python_path)
@@ -277,10 +229,7 @@ def run_pyctest():
     # set directory to run test
     test.SetProperty("WORKING_DIRECTORY", pyctest.BINARY_DIRECTORY)
     test.SetProperty("ENVIRONMENT", "OMP_NUM_THREADS=1")
-
-    #--------------------------------------------------------------------------#
     # Generating C code coverage is enabled
-    #
     if args.coverage:
         # if generating C code coverage, generating the Python coverage
         # needs to be put inside a test (that runs after nosetest)
@@ -299,17 +248,13 @@ def run_pyctest():
         test.SetProperty("WORKING_DIRECTORY", pyctest.BINARY_DIRECTORY)
         test.SetProperty("DEPENDS", "nosetests")
         test.SetCommand(coverage_cmd)
-
-    #--------------------------------------------------------------------------#
     # If path to globus is provided, skip when generating C coverage (too long)
-    #
     if not args.coverage and args.globus_path is not None:
         phantom = "tomo_00001"
         h5file = os.path.join(args.globus_path, phantom, phantom + ".h5")
         if not os.path.exists(h5file):
             print("Warning! HDF5 file '{}' does not exists! Skipping test...".format(h5file))
             h5file = None
-
         # loop over args.algorithms and create tests for each
         for algorithm in args.algorithms:
             test = pyctest.test()
@@ -338,10 +283,7 @@ def run_pyctest():
                                 "-o", "benchmarking/{}".format(name),
                                 "-n", "{}".format(args.ncores),
                                 "-i", "{}".format(args.num_iter)])
-
-    #--------------------------------------------------------------------------#
     # loop over args.phantoms, skip when generating C coverage (too long)
-    #
     if not args.coverage and not args.disable_phantom_tests:
         for phantom in args.phantoms:
             # create a test comparing all the args.algorithms
@@ -354,7 +296,6 @@ def run_pyctest():
                 nsize = (args.phantom_size if phantom != "shepp3d" else
                          int(args.phantom_size / 4))
                 name = "{}_pix{}".format(name, nsize)
-
             # original number of iterations before num-iter added to test name
             if args.num_iter != 10:
                 name = "{}_itr{}".format(name, args.num_iter)
@@ -378,34 +319,20 @@ def run_pyctest():
                             "-i", "{}".format(niters),
                             "--output-dir", "benchmarking/{}".format(name),
                             "--compare"] + args.algorithms)
-
-    #--------------------------------------------------------------------------#
     # generate the CTestConfig.cmake and CTestCustom.cmake
-    #
     pyctest.generate_config(pyctest.BINARY_DIRECTORY)
-
-    #--------------------------------------------------------------------------#
     # generate the CTestTestfile.cmake file
-    #
     pyctest.generate_test_file(pyctest.BINARY_DIRECTORY)
-
-    #--------------------------------------------------------------------------#
     # run CTest
-    #
     pyctest.run(pyctest.ARGUMENTS, pyctest.BINARY_DIRECTORY)
 
 
-#------------------------------------------------------------------------------#
 if __name__ == "__main__":
-
     try:
-
         run_pyctest()
-
     except Exception as e:
         print('Error running pyctest - {}'.format(e))
         exc_type, exc_value, exc_trback = sys.exc_info()
         traceback.print_exception(exc_type, exc_value, exc_trback, limit=10)
         sys.exit(1)
-
     sys.exit(0)

--- a/pyctest_tomopy.py
+++ b/pyctest_tomopy.py
@@ -41,16 +41,16 @@ def configure():
                                     submit=False,
                                     ctest_args=["-V"])
     # default algorithm choices
-    available_algorithms = ['gridrec', 'art', 'fbp', 'bart', 'mlem', 'osem', 'sirt',
-                            'ospml_hybrid', 'ospml_quad', 'pml_hybrid', 'pml_quad',
-                            'tv', 'grad']
+    available_algorithms = ['gridrec', 'art', 'fbp', 'bart', 'mlem', 'osem',
+                            'sirt', 'ospml_hybrid', 'ospml_quad', 'pml_hybrid',
+                            'pml_quad', 'tv', 'grad']
     # default phantom choices
     available_phantoms = ["baboon", "cameraman", "barbara", "checkerboard",
                           "lena", "peppers", "shepp2d", "shepp3d"]
     # choices for algorithms
-    algorithm_choices = ['gridrec', 'art', 'fbp', 'bart', 'mlem', 'osem', 'sirt',
-                         'ospml_hybrid', 'ospml_quad', 'pml_hybrid', 'pml_quad',
-                         'tv', 'grad', 'none', 'all']
+    algorithm_choices = ['gridrec', 'art', 'fbp', 'bart', 'mlem', 'osem',
+                         'sirt', 'ospml_hybrid', 'ospml_quad', 'pml_hybrid',
+                         'pml_quad', 'tv', 'grad', 'none', 'all']
     # phantom choices
     phantom_choices = ["baboon", "cameraman", "barbara", "checkerboard",
                        "lena", "peppers", "shepp2d", "shepp3d", "none", "all"]
@@ -59,9 +59,9 @@ def configure():
     # number of cores
     default_ncores = multiprocessing.cpu_count()
     # default algorithm choices
-    default_algorithms = ['gridrec', 'art', 'fbp', 'bart', 'mlem', 'osem', 'sirt',
-                          'ospml_hybrid', 'ospml_quad', 'pml_hybrid', 'pml_quad',
-                          'tv', 'grad']
+    default_algorithms = ['gridrec', 'art', 'fbp', 'bart', 'mlem', 'osem',
+                          'sirt', 'ospml_hybrid', 'ospml_quad', 'pml_hybrid',
+                          'pml_quad', 'tv', 'grad']
     # default phantom choices
     default_phantoms = ["baboon", "cameraman", "barbara", "checkerboard",
                         "lena", "peppers", "shepp2d", "shepp3d"]
@@ -188,7 +188,8 @@ def run_pyctest():
         if gcov_cmd is not None:
             pyctest.COVERAGE_COMMAND = "{}".format(gcov_cmd)
             pyctest.set("CTEST_COVERAGE_EXTRA_FLAGS", "-m")
-            pyctest.set("CTEST_EXTRA_COVERAGE_GLOB", "{}/*.gcno".format(pyctest.SOURCE_DIRECTORY))
+            pyctest.set("CTEST_EXTRA_COVERAGE_GLOB", "{}/*.gcno".format(
+                pyctest.SOURCE_DIRECTORY))
     else:
         # assign to just generate python coverage
         pyctest.COVERAGE_COMMAND = "{};xml".format(cover_exe)
@@ -225,7 +226,8 @@ def run_pyctest():
     if coverage_exe is None:
         coverage_exe = helpers.FindExePath("coverage")
     # python $(which coverage) run $(which nosetests)
-    test.SetCommand([pyctest.PYTHON_EXECUTABLE, coverage_exe, "run", nosetest_exe])
+    test.SetCommand([pyctest.PYTHON_EXECUTABLE, coverage_exe, "run",
+                    nosetest_exe])
     # set directory to run test
     test.SetProperty("WORKING_DIRECTORY", pyctest.BINARY_DIRECTORY)
     test.SetProperty("ENVIRONMENT", "OMP_NUM_THREADS=1")
@@ -253,7 +255,8 @@ def run_pyctest():
         phantom = "tomo_00001"
         h5file = os.path.join(args.globus_path, phantom, phantom + ".h5")
         if not os.path.exists(h5file):
-            print("Warning! HDF5 file '{}' does not exists! Skipping test...".format(h5file))
+            print("Warning! HDF5 file '{}' does not exists! "
+                  "Skipping test...".format(h5file))
             h5file = None
         # loop over args.algorithms and create tests for each
         for algorithm in args.algorithms:
@@ -271,6 +274,7 @@ def run_pyctest():
                                 "-c",
                                 "print(\"Path to Globus file '{}/{}.h5' not specified\")".format(
                                     phantom, phantom)])
+
             else:
                 test.SetCommand([pyctest.PYTHON_EXECUTABLE,
                                 ".//benchmarking/pyctest_tomopy_rec.py",


### PR DESCRIPTION
These commits do three things:

1. Remove extra white space from the benchmarks around indents and lines that are already separated by comments
2. Add line breaks at 80 characters
3. Use Python membership syntax which is `foo not in bar` instead of `not foo in bar`

A feature of the language that you seem not to be familiar with is string literals via the triple quotation mark. You had some code chunks as strings which were hard to read because they were the concatenation of multiple strings that also contained strings and newlines. I replaced those with triple quote string literals, so the code can be viewed as code.

"""
import os, sys, tomopy
print('using tomopy module: {}'.format(tomopy.__file__))
ret=0 if os.getcwd() in tomopy.__file__ else 1
sys.exit(ret)
"""
