### PR TITLE
BLD: Test on conda-available-gcc

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -15,23 +15,12 @@ version: 1.0.{build}
 branches:
   only:
     - master
-    - dev
-# Do not build on tags (GitHub and BitBucket)
-# skip_tags: true
-# Start builds on tags only (GitHub and BitBucket)
-# skip_non_tags: true
 # Skipping commits affecting specific files (GitHub only).
 # More details here: /docs/appveyor-yml
 skip_commits:
  files:
    - docs/*
    - '**/*.html'
-# Including commits affecting specific files (GitHub only).
-# More details here: /docs/appveyor-yml
-#only_commits:
-#  files:
-#    - Project-A/
-#    - Project-B/
 # Do not build feature branch with open Pull Requests
 skip_branch_with_pr: true
 # Maximum number of concurrent jobs for the project
@@ -82,23 +71,8 @@ install:
 platform: x64
 # build Configuration, i.e. Debug, Release, etc.
 configuration: Debug
-
-# scripts to run before build
-before_build:
-
-# to run your custom scripts instead of automatic MSBuild
 build_script:
   - python setup.py install
-# scripts to run after build (working directory and environment changes are
-# persisted from the previous steps)
-after_build:
-
-# scripts to run *after* solution is built and *before* automatic packaging
-# occurs (web apps, NuGet packages, Azure Cloud Services)
-before_package:
-
-# to disable automatic builds
-#build: off
 #---------------------------------#
 #       tests configuration       #
 #---------------------------------#
@@ -109,8 +83,3 @@ before_test:
 # to run your custom scripts instead of automatic tests
 test_script:
   - nosetests test
-# scripts to run after tests
-after_test:
-
-# to disable automatic tests
-#test: off

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -49,7 +49,7 @@ shallow_clone: true                 # default is "false"
 # environment variables
 environment:
   # these variables are common to all jobs
-  MINGW_PATH: "C:\\mingw-w64\\x86_64-7.2.0-posix-seh-rt_v5-rev1\\mingw64"
+  MINGW_PATH: "C:\\mingw-w64\\i686-5.3.0-posix-dwarf-rt_v4-rev0\\mingw32"
   matrix:
     - PYTHON_VERSION: "3.5"
       MINICONDA: "C:\\Miniconda35-x64"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -53,6 +53,7 @@ matrix:
 # scripts that run after cloning repository
 install:
   - "set PATH=%MINGW_PATH%\\bin;%MINICONDA%;%MINICONDA%\\Scripts;%PATH%"
+  - where gcc
   - conda config --set always_yes True
   - conda config --add channels conda-forge
   - conda config --add channels jrmadsen

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -46,7 +46,7 @@ environment:
       MINICONDA: "C:\\Miniconda36-x64"
 matrix:
   # set this flag to immediately finish build once one of the jobs fails.
-  fast_finish: false
+  fast_finish: true
 # build cache to preserve files/folders between builds
 # cache:
 #   - projectA\libs

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -38,7 +38,6 @@ shallow_clone: true                 # default is "false"
 # environment variables
 environment:
   # these variables are common to all jobs
-  MINGW_PATH: "C:\\mingw-w64\\i686-5.3.0-posix-dwarf-rt_v4-rev0\\mingw32"
   matrix:
     - PYTHON_VERSION: "3.5"
       MINICONDA: "C:\\Miniconda35-x64"
@@ -52,14 +51,14 @@ matrix:
 #   - projectA\libs
 # scripts that run after cloning repository
 install:
-  - "set PATH=%MINGW_PATH%\\bin;%MINICONDA%;%MINICONDA%\\Scripts;%PATH%"
-  - where gcc
+  - "set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%"
   - conda config --set always_yes True
   - conda config --add channels conda-forge
   - conda config --add channels jrmadsen
   - conda update conda  # required in order to find mkl-devel
   - >
       conda install
+      m2w64-gcc
       mkl mkl-devel mkl_fft
       nose
       numexpr
@@ -73,6 +72,7 @@ install:
   # Check that we have the expected version and architecture for Python
   - conda info -a
   - "python --version"
+  - where gcc
 #---------------------------------#
 #       build configuration       #
 #---------------------------------#
@@ -81,6 +81,7 @@ platform: x64
 # build Configuration, i.e. Debug, Release, etc.
 configuration: Debug
 build_script:
+  - set CC=gcc
   - python setup.py install
 #---------------------------------#
 #       tests configuration       #

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -87,7 +87,7 @@ build_script:
 # scripts to run before tests (working directory and environment changes are
 # persisted from the previous steps such as "before_build")
 before_test:
-
+  - cd test/
 # to run your custom scripts instead of automatic tests
 test_script:
-  - nosetests test
+  - nosetests -v

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -56,11 +56,19 @@ install:
   - conda config --set always_yes True
   - conda config --add channels conda-forge
   - conda config --add channels jrmadsen
-  - conda update conda
-  - "conda install
-    python=%PYTHON_VERSION% mkl-devel mkl mingw make setuptools
-    nose dxchange mkl_fft numexpr numpy
-    scipy scikit-image six"
+  - conda update conda  # required in order to find mkl-devel
+  - >
+      conda install
+      mkl mkl-devel mkl_fft
+      nose
+      numexpr
+      numpy
+      python=%PYTHON_VERSION%
+      scipy
+      scikit-build
+      scikit-image
+      setuptools
+      six
   # Check that we have the expected version and architecture for Python
   - conda info -a
   - "python --version"


### PR DESCRIPTION
Although there is a more recent version of GCC available on the Appveyor VM (v7.x), we should be testing with the version that is available from Anaconda defaults (v5.3) because that is what is available to our conda-forge build infrastructure. In this pull request, I tried to get the pre-installed Appveyor MinGW (v5.3) working, but there were some linking errors which I coudn't resolve. Thus, I am using GCC from the defaults channel. It will need to be installed every time, but it works.